### PR TITLE
Make Cursor implementation public

### DIFF
--- a/sqlite.rc
+++ b/sqlite.rc
@@ -271,7 +271,7 @@ pub fn sqlite_complete(sql: &str) -> SqliteResult<bool> {
   }
 }
 
-impl Cursor {
+pub impl Cursor {
   fn reset(&self) -> ResultCode {
     unsafe {
       sqlite3::sqlite3_reset(self.stmt)


### PR DESCRIPTION
Without this, I can't use the Cursor returned by `prepare`, because `step`, `get_int`, etc are private.
