### PR TITLE
Make work with latest incoming

### DIFF
--- a/sqlite.rc
+++ b/sqlite.rc
@@ -191,14 +191,17 @@ pub impl Database {
   }
 }
 
-enum dbh {}
-enum stmt {}
+pub enum dbh {}
+pub enum stmt {}
 
-enum _notused {}
+pub enum _notused {}
 
 mod sqlite3 {
+  use core::libc::*;
   use super::*;
-  extern {
+
+  #[link_args="-lsqlite3"]
+  pub extern {
     fn sqlite3_open(path: *c_char, hnd: **dbh) -> ResultCode;
     fn sqlite3_close(dbh: *dbh) -> ResultCode;
     fn sqlite3_errmsg(dbh: *dbh) -> *c_char;


### PR DESCRIPTION
- `extern mod sqlite3` => `mod sqlite3 { extern {`
- make definitions/imports accessible to that mod
- `fail!` now also accepts static strings
