### PR TITLE
Adding explicit mod extern for libraries

### DIFF
--- a/cursor.rs
+++ b/cursor.rs
@@ -29,6 +29,9 @@
 ** POSSIBILITY OF SUCH DAMAGE.
 */
 
+extern mod ffi;
+extern mod types;
+
 use ffi::*;
 use std::libc::*;
 use std::hashmap::HashMap;

--- a/database.rs
+++ b/database.rs
@@ -29,6 +29,10 @@
 ** POSSIBILITY OF SUCH DAMAGE.
 */
 
+extern mod cursor;
+extern mod ffi;
+extern mod types;
+
 use cursor::*;
 use ffi::*;
 use std::libc::*;

--- a/ffi.rs
+++ b/ffi.rs
@@ -29,6 +29,8 @@
 ** POSSIBILITY OF SUCH DAMAGE.
 */
 
+extern mod types;
+
 use std::libc::*;
 use types::*;
 


### PR DESCRIPTION
Perhaps I'm doing it wrong, but I had to add `extern mod` statements to your crates to get them to compile.
