### PR TITLE
Use f64 instead of float.

### DIFF
--- a/cursor.rs
+++ b/cursor.rs
@@ -86,7 +86,7 @@ impl Cursor {
     }
   }
 
-  /// 
+  ///
   pub fn step_row(&self) -> SqliteResult<Option<RowMap>> {
     let is_row: ResultCode = self.step();
     if is_row == SQLITE_ROW {
@@ -118,7 +118,7 @@ impl Cursor {
     }
   }
 
-  /// 
+  ///
   /// See http://www.sqlite.org/c3ref/column_blob.html
   #[fixed_stack_segment]
   pub fn get_bytes(&self, i: int) -> int {
@@ -127,7 +127,7 @@ impl Cursor {
     }
   }
 
-  /// 
+  ///
   /// See http://www.sqlite.org/c3ref/column_blob.html
   #[fixed_stack_segment]
   pub fn get_blob(&self, i: int) -> ~[u8] {
@@ -141,7 +141,7 @@ impl Cursor {
     }
   }
 
-  /// 
+  ///
   /// See http://www.sqlite.org/c3ref/column_blob.html
   #[fixed_stack_segment]
   pub fn get_int(&self, i: int) -> int {
@@ -150,16 +150,16 @@ impl Cursor {
     }
   }
 
-  /// 
+  ///
   /// See http://www.sqlite.org/c3ref/column_blob.html
   #[fixed_stack_segment]
-  pub fn get_num(&self, i: int) -> float {
+  pub fn get_num(&self, i: int) -> f64 {
     unsafe {
       return sqlite3_column_double(self.stmt, i as c_int);
     }
   }
 
-  /// 
+  ///
   /// See http://www.sqlite.org/c3ref/column_blob.html
   #[fixed_stack_segment]
   pub fn get_text(&self, i: int) -> ~str {
@@ -168,7 +168,7 @@ impl Cursor {
     }
   }
 
-  /// 
+  ///
   /// See http://www.sqlite.org/c3ref/bind_parameter_index.html
   #[fixed_stack_segment]
   pub fn get_bind_index(&self, name: &str) -> int {
@@ -229,7 +229,7 @@ impl Cursor {
     return r;
   }
 
-  /// 
+  ///
   pub fn bind_params(&self, values: &[BindArg]) -> ResultCode {
     let mut i = 0i;
     for v in values.iter() {
@@ -242,7 +242,7 @@ impl Cursor {
     return SQLITE_OK;
   }
 
-  /// 
+  ///
   /// See http://www.sqlite.org/c3ref/bind_blob.html
   #[fixed_stack_segment]
   pub fn bind_param(&self, i: int, value: &BindArg) -> ResultCode {

--- a/ffi.rs
+++ b/ffi.rs
@@ -63,14 +63,14 @@ extern {
   pub fn sqlite3_column_blob(sth: *stmt, icol: c_int) -> *u8;
 
   pub fn sqlite3_column_text(sth: *stmt, icol: c_int) -> *c_char;
-  pub fn sqlite3_column_double(sth: *stmt, icol: c_int) -> float;
+  pub fn sqlite3_column_double(sth: *stmt, icol: c_int) -> f64;
   pub fn sqlite3_column_int(sth: *stmt, icol: c_int) -> c_int;
 
   pub fn sqlite3_bind_blob(sth: *stmt, icol: c_int, buf: *u8, buflen: c_int, d: c_int) -> ResultCode;
   pub fn sqlite3_bind_text(sth: *stmt, icol: c_int, buf: *c_char, buflen: c_int, d: c_int) -> ResultCode;
   pub fn sqlite3_bind_null(sth: *stmt, icol: c_int) -> ResultCode;
   pub fn sqlite3_bind_int(sth: *stmt, icol: c_int, v: c_int) -> ResultCode;
-  pub fn sqlite3_bind_double(sth: *stmt, icol: c_int, value: float) -> ResultCode;
+  pub fn sqlite3_bind_double(sth: *stmt, icol: c_int, value: f64) -> ResultCode;
   pub fn sqlite3_bind_parameter_index(sth: *stmt, name: *c_char) -> c_int;
 
   pub fn sqlite3_busy_timeout(dbh: *dbh, ms: c_int) -> ResultCode;

--- a/types.rs
+++ b/types.rs
@@ -104,7 +104,7 @@ impl to_str::ToStr for ResultCode {
 #[deriving(Eq)]
 pub enum BindArg {
   Text(~str),
-  Number(float),
+  Number(f64),
   Integer(int),
   Blob(~[u8]),
   Null,


### PR DESCRIPTION
`float` has been removed from the language. SQLite documents their REAL type
as being an [f64](), so use that. Exposes a correctness bug where Rust
wouldn't pick f32 as the float type.

[f64] - http://sqlite.org/datatype3.html
