### PR TITLE
Fix destructor type in FFI for bind_text/blob

### DIFF
--- a/src/sqlite/cursor.rs
+++ b/src/sqlite/cursor.rs
@@ -238,7 +238,7 @@ impl Cursor {
 
         let r = match *value {
             Text(ref v) => {
-                let l = v.len() + 1;
+                let l = v.len();
                 debug!("  `Text`: v={:?}, l={:?}", v, l);
 
                 (*v).with_c_str( |_v| {
@@ -250,7 +250,7 @@ impl Cursor {
                             , i as c_int  // the SQL parameter index (starting from 1)
                             , _v          // the value to bind
                             , l as c_int  // the number of bytes
-                            , -1 as c_int // SQLITE_TRANSIENT => SQLite makes a copy
+                            , -1 as *c_void// SQLITE_TRANSIENT => SQLite makes a copy
                             )
                     }
                 })
@@ -267,7 +267,7 @@ impl Cursor {
                         , i as c_int  // the SQL parameter index (starting from 1)
                         , v.as_ptr()  // the value to bind
                         , l as c_int  // the number of bytes
-                        , -1 as c_int // SQLITE_TRANSIENT => SQLite makes a copy
+                        , -1 as *c_void // SQLITE_TRANSIENT => SQLite makes a copy
                         )
                 }
             }

--- a/src/sqlite/ffi.rs
+++ b/src/sqlite/ffi.rs
@@ -66,8 +66,8 @@ extern {
     pub fn sqlite3_column_double(sth: *stmt, icol: c_int) -> f64;
     pub fn sqlite3_column_int(sth: *stmt, icol: c_int) -> c_int;
 
-    pub fn sqlite3_bind_blob(sth: *stmt, icol: c_int, buf: *u8, buflen: c_int, d: c_int) -> ResultCode;
-    pub fn sqlite3_bind_text(sth: *stmt, icol: c_int, buf: *c_char, buflen: c_int, d: c_int) -> ResultCode;
+    pub fn sqlite3_bind_blob(sth: *stmt, icol: c_int, buf: *u8, buflen: c_int, d: *c_void) -> ResultCode;
+    pub fn sqlite3_bind_text(sth: *stmt, icol: c_int, buf: *c_char, buflen: c_int, d: *c_void) -> ResultCode;
     pub fn sqlite3_bind_null(sth: *stmt, icol: c_int) -> ResultCode;
     pub fn sqlite3_bind_int(sth: *stmt, icol: c_int, v: c_int) -> ResultCode;
     pub fn sqlite3_bind_double(sth: *stmt, icol: c_int, value: f64) -> ResultCode;


### PR DESCRIPTION
This fixes a segfault in the associated tests.
