### PR TITLE
Ensure that a cursor outlives its database

### DIFF
--- a/src/sqlite/cursor.rs
+++ b/src/sqlite/cursor.rs
@@ -37,16 +37,18 @@ use std::vec;
 use types::*;
 
 /// The database cursor.
-pub struct Cursor {
+pub struct Cursor<'db> {
     priv stmt: *stmt,
+    priv dbh: &'db *dbh
 }
 
-pub fn cursor_with_statement(stmt: *stmt) -> Cursor {
+pub fn cursor_with_statement<'db>(stmt: *stmt, dbh: &'db *dbh) -> Cursor<'db> {
     debug!("`Cursor.cursor_with_statement()`: stmt={:?}", stmt);
-    Cursor { stmt: stmt }
+    Cursor { stmt: stmt, dbh: dbh }
 }
 
-impl Drop for Cursor {
+#[unsafe_destructor]
+impl<'db> Drop for Cursor<'db> {
     /// Deletes a prepared SQL statement.
     /// See http://www.sqlite.org/c3ref/finalize.html
     fn drop(&mut self) {
@@ -57,7 +59,7 @@ impl Drop for Cursor {
     }
 }
 
-impl Cursor {
+impl<'db> Cursor<'db> {
 
     /// Resets a prepared SQL statement, but does not reset its bindings.
     /// See http://www.sqlite.org/c3ref/reset.html

--- a/src/sqlite/database.rs
+++ b/src/sqlite/database.rs
@@ -68,7 +68,7 @@ impl Database {
 
     /// Prepares/compiles an SQL statement.
     /// See http://www.sqlite.org/c3ref/prepare.html
-    pub fn prepare(&self, sql: &str, _tail: &Option<&str>) -> SqliteResult<Cursor> {
+    pub fn prepare<'db>(&'db self, sql: &str, _tail: &Option<&str>) -> SqliteResult<Cursor<'db>> {
         let new_stmt = ptr::null();
         let r = sql.with_c_str( |_sql| {
             unsafe {
@@ -77,7 +77,7 @@ impl Database {
         });
         if r == SQLITE_OK {
             debug!("`Database.prepare()`: stmt={:?}", new_stmt);
-            Ok( cursor_with_statement(new_stmt))
+            Ok( cursor_with_statement(new_stmt, &self.dbh))
         } else {
             Err(r)
         }

--- a/src/sqlite/lib.rs
+++ b/src/sqlite/lib.rs
@@ -90,7 +90,7 @@ mod tests {
     use super::*;
     use types::*;
 
-    fn checked_prepare(database: Database, sql: &str) -> Cursor {
+    fn checked_prepare<'db>(database: &'db Database, sql: &str) -> Cursor<'db> {
         match database.prepare(sql, &None) {
             Ok(s)  => s,
             Err(x) => fail!(format!("sqlite error: \"{}\" ({:?})", database.get_errmsg(), x)),
@@ -125,7 +125,7 @@ mod tests {
         let database = checked_open();
 
         checked_exec(&database, "BEGIN; CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY AUTOINCREMENT); COMMIT;");
-        let sth = checked_prepare(database, "INSERT OR IGNORE INTO test (id) VALUES (1)");
+        let sth = checked_prepare(&database, "INSERT OR IGNORE INTO test (id) VALUES (1)");
         let res = sth.step();
         debug!("test `prepare_insert_stmt`: res={:?}", res);
     }
@@ -141,7 +141,7 @@ mod tests {
             COMMIT;"
         );
 
-        let sth = checked_prepare(database, "SELECT id FROM test WHERE id = 1;");
+        let sth = checked_prepare(&database, "SELECT id FROM test WHERE id = 1;");
         assert!(sth.step() == SQLITE_ROW);
         assert!(sth.get_int(0) == 1);
         assert!(sth.step() == SQLITE_DONE);
@@ -158,7 +158,7 @@ mod tests {
                 INSERT OR IGNORE INTO test (id) VALUES(3);
                 INSERT OR IGNORE INTO test (id) VALUES(4);"
         );
-        let sth = checked_prepare(database, "SELECT id FROM test WHERE id > ? AND id < ?");
+        let sth = checked_prepare(&database, "SELECT id FROM test WHERE id > ? AND id < ?");
         assert!(sth.bind_param(1, &Integer(2)) == SQLITE_OK);
         assert!(sth.bind_param(2, &Integer(4)) == SQLITE_OK);
 
@@ -172,7 +172,7 @@ mod tests {
 
         checked_exec(&database, "BEGIN; CREATE TABLE IF NOT EXISTS test (name text); COMMIT;");
 
-        let sth = checked_prepare(database, "INSERT INTO test (name) VALUES (?)");
+        let sth = checked_prepare(&database, "INSERT INTO test (name) VALUES (?)");
 
         println!("test `prepared_stmt_bind_text()` currently segfaults here:");
         assert!(sth.bind_param(1, &Text(~"test")) == SQLITE_OK);
@@ -188,7 +188,7 @@ mod tests {
                 INSERT OR IGNORE INTO test (id, v) VALUES(1, 'leeeee');
                 COMMIT;"
         );
-        let sth = checked_prepare(database, "SELECT * FROM test");
+        let sth = checked_prepare(&database, "SELECT * FROM test");
         assert!(sth.step() == SQLITE_ROW);
         assert!(sth.get_column_names() == ~[~"id", ~"v"]);
     }
@@ -204,7 +204,7 @@ mod tests {
                 INSERT OR IGNORE INTO test (id, v) VALUES(1, 'leeeee');
                 COMMIT;"
         );
-        let _sth = checked_prepare(database, "SELECT q FRO test");
+        let _sth = checked_prepare(&database, "SELECT q FRO test");
     }
 
     #[test]
@@ -217,7 +217,7 @@ mod tests {
                 INSERT OR IGNORE INTO test (id, v) VALUES(1, 'leeeee');
                 COMMIT;"
         );
-        let sth = checked_prepare(database, "SELECT * FROM test WHERE v=:Name");
+        let sth = checked_prepare(&database, "SELECT * FROM test WHERE v=:Name");
         assert!(sth.get_bind_index(":Name") == 1);
     }
 
@@ -249,7 +249,7 @@ mod tests {
             COMMIT;
             "
         );
-        let sth = checked_prepare(database, "SELECT * FROM test WHERE id=2");
+        let sth = checked_prepare(&database, "SELECT * FROM test WHERE id=2");
         let r = sth.step_row();
         let possible_row = r.unwrap();
         match possible_row {


### PR DESCRIPTION
Cursors now borrow a pointer to the database handle. This changes the prepare() api.

If you turn on debug logging before applying this commit, you can see the database's Drop running before the cursor's.

I'm no rust expert, so this may not be the best way.
