### PR TITLE
Language changes: std::libc -> libc.

### DIFF
--- a/src/sqlite3/cursor.rs
+++ b/src/sqlite3/cursor.rs
@@ -30,7 +30,7 @@
 */
 
 use ffi::*;
-use std::libc::*;
+use libc::{c_int, c_void};
 use collections::hashmap::HashMap;
 use std::str;
 use std::slice;

--- a/src/sqlite3/database.rs
+++ b/src/sqlite3/database.rs
@@ -31,7 +31,7 @@
 
 use cursor::*;
 use ffi::*;
-use std::libc::*;
+use libc::c_int;
 use std::ptr;
 use std::str;
 use types::*;

--- a/src/sqlite3/ffi.rs
+++ b/src/sqlite3/ffi.rs
@@ -29,7 +29,7 @@
 ** POSSIBILITY OF SUCH DAMAGE.
 */
 
-use std::libc::*;
+use libc::*;
 use types::*;
 
 #[link(name = "sqlite3")]

--- a/src/sqlite3/lib.rs
+++ b/src/sqlite3/lib.rs
@@ -34,6 +34,7 @@
 ** POSSIBILITY OF SUCH DAMAGE.
 */
 
+extern crate libc;
 extern crate collections;
 
 pub use cursor::*;


### PR DESCRIPTION
This commit also avoids glob imports on libc since `libc::Nullable` has a `Some` variant which shadows the prelude's `Some`.
