### PR TITLE
Language changes: `buf` field in `core::fmt::Formatter` is now private.

### DIFF
--- a/src/sqlite3/types.rs
+++ b/src/sqlite3/types.rs
@@ -68,7 +68,7 @@ pub enum ResultCode {
 
 impl fmt::Show for ResultCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.buf.write(match *self {
+        f.write(match *self {
             SQLITE_OK => "Ok".as_bytes(),
             SQLITE_ERROR => "SQLITE_ERROR".as_bytes(),
             SQLITE_INTERNAL => "SQLITE_INTERNAL".as_bytes(),


### PR DESCRIPTION
Cf. mozilla/rust@cf0619383d2ce0f7bd822f82cf487c7fa33d0b76
