### PR TITLE
Language changes: ~str -> StrBuf.

### DIFF
--- a/src/sqlite3/cursor.rs
+++ b/src/sqlite3/cursor.rs
@@ -162,7 +162,7 @@ impl<'db> Cursor<'db> {
 
     ///
     /// See http://www.sqlite.org/c3ref/column_blob.html
-    pub fn get_text(&self, i: int) -> ~str {
+    pub fn get_text(&self, i: int) -> StrBuf {
         unsafe {
             return str::raw::from_c_str( sqlite3_column_text(self.stmt, i as c_int) );
         }
@@ -189,7 +189,7 @@ impl<'db> Cursor<'db> {
 
     /// Returns the name of the column with index `i` in the result set.
     /// See http://www.sqlite.org/c3ref/column_name.html
-    pub fn get_column_name(&self, i: int) -> ~str {
+    pub fn get_column_name(&self, i: int) -> StrBuf {
         unsafe {
             return str::raw::from_c_str( sqlite3_column_name(self.stmt, i as c_int) );
         }
@@ -214,7 +214,7 @@ impl<'db> Cursor<'db> {
     }
 
     /// Returns the names of all columns in the result set.
-    pub fn get_column_names(&self) -> Vec<~str> {
+    pub fn get_column_names(&self) -> Vec<StrBuf> {
         let cnt = self.get_column_count();
         let mut i = 0;
         let mut r = Vec::new();

--- a/src/sqlite3/database.rs
+++ b/src/sqlite3/database.rs
@@ -60,7 +60,7 @@ impl Database {
 
     /// Returns the error message of the the most recent call.
     /// See http://www.sqlite.org/c3ref/errcode.html
-    pub fn get_errmsg(&self) -> ~str {
+    pub fn get_errmsg(&self) -> StrBuf {
         unsafe {
             str::raw::from_c_str(sqlite3_errmsg(self.dbh))
         }

--- a/src/sqlite3/types.rs
+++ b/src/sqlite3/types.rs
@@ -104,7 +104,7 @@ impl fmt::Show for ResultCode {
 
 #[deriving(Eq)]
 pub enum BindArg {
-    Text(~str),
+    Text(StrBuf),
     StaticText(&'static str),
     Float64(f64),
     Integer(int),
@@ -123,7 +123,7 @@ pub enum ColumnType {
 
 pub type SqliteResult<T> = Result<T, ResultCode>;
 
-pub type RowMap = HashMap<~str, BindArg>;
+pub type RowMap = HashMap<StrBuf, BindArg>;
 
 pub enum dbh {}
 pub enum stmt {}


### PR DESCRIPTION
This won't really change things, as the standard library has completely moved from `~str` now.
