### PR TITLE
Language changes: {:?} now requires libdebug.

### DIFF
--- a/src/sqlite3/lib.rs
+++ b/src/sqlite3/lib.rs
@@ -2,6 +2,7 @@
 #![crate_type = "lib"]
 #![feature(globs, phase)]
 #[phase(syntax, link)] extern crate log;
+extern crate debug;
 
 /*
 ** Copyright (c) 2011, Brian Smith <brian@linuxfood.net>


### PR DESCRIPTION
Note that I have a bad feeling about this, since the line added should be actually guarded with `#[cfg(not(ndebug))]` but it cannot due to how the `debug!` macro works. Any better solution would be welcomed.
