### PR TITLE
Language changes: to_owned() on &str is being deprecated.

### DIFF
--- a/src/sqlite3/lib.rs
+++ b/src/sqlite3/lib.rs
@@ -221,7 +221,7 @@ mod tests {
 
         let sth = checked_prepare(&database, "INSERT INTO test (name) VALUES (?)");
 
-        assert!(sth.bind_param(1, &Text("test".to_owned())) == SQLITE_OK);
+        assert!(sth.bind_param(1, &Text("test".to_string())) == SQLITE_OK);
     }
 
     #[test]
@@ -247,7 +247,7 @@ mod tests {
         );
         let sth = checked_prepare(&database, "SELECT * FROM test");
         assert!(sth.step() == SQLITE_ROW);
-        assert!(sth.get_column_names() == vec!("id".to_owned(), "v".to_owned()));
+        assert!(sth.get_column_names() == vec!("id".to_string(), "v".to_string()));
     }
 
     #[test]
@@ -312,9 +312,9 @@ mod tests {
         match possible_row {
             Some(x) => {
                 let mut x = x;
-                assert!(x.pop(&"id".to_owned()) == Some(Integer(2)));
-                assert!(x.pop(&"k".to_owned())  == Some(Text("e".to_owned())));
-                assert!(x.pop(&"v".to_owned())  == Some(Float64(2.17)));
+                assert!(x.pop(&"id".to_string()) == Some(Integer(2)));
+                assert!(x.pop(&"k".to_string())  == Some(Text("e".to_string())));
+                assert!(x.pop(&"v".to_string())  == Some(Float64(2.17)));
             }
             None => {
                 fail!("didnt get even one row back.");


### PR DESCRIPTION
This commit should prevent tests from being failed in the future.
