### PR TITLE
Language changes: libcollections -> std::collections.

### DIFF
--- a/src/sqlite3/cursor.rs
+++ b/src/sqlite3/cursor.rs
@@ -31,7 +31,7 @@
 
 use ffi::*;
 use libc::{c_int, c_void};
-use collections::hashmap::HashMap;
+use std::collections::HashMap;
 use std::str;
 use std::slice;
 use types::*;

--- a/src/sqlite3/lib.rs
+++ b/src/sqlite3/lib.rs
@@ -36,7 +36,6 @@ extern crate debug;
 */
 
 extern crate libc;
-extern crate collections;
 
 pub use cursor::*;
 pub use database::*;

--- a/src/sqlite3/types.rs
+++ b/src/sqlite3/types.rs
@@ -29,7 +29,7 @@
 ** POSSIBILITY OF SUCH DAMAGE.
 */
 
-use collections::hashmap::HashMap;
+use std::collections::HashMap;
 use std::fmt;
 
 #[deriving(PartialEq, Eq)]


### PR DESCRIPTION
`collections` are now reexported from `std::collections` (and has no dependency for `std`), so we no longer need to depend on `collections`.
