### PR TITLE
Language changes: #[unsafe_destructor] gets feature-gated, avoids some warnings.

### DIFF
--- a/src/sqlite3/cursor.rs
+++ b/src/sqlite3/cursor.rs
@@ -39,12 +39,12 @@ use types::*;
 /// The database cursor.
 pub struct Cursor<'db> {
     stmt: *stmt,
-    dbh: &'db *dbh
+    _dbh: &'db *dbh
 }
 
 pub fn cursor_with_statement<'db>(stmt: *stmt, dbh: &'db *dbh) -> Cursor<'db> {
     debug!("`Cursor.cursor_with_statement()`: stmt={:?}", stmt);
-    Cursor { stmt: stmt, dbh: dbh }
+    Cursor { stmt: stmt, _dbh: dbh }
 }
 
 #[unsafe_destructor]

--- a/src/sqlite3/lib.rs
+++ b/src/sqlite3/lib.rs
@@ -1,7 +1,7 @@
 #![crate_id="sqlite3#0.1"]
 #![crate_type = "lib"]
-#![feature(globs, phase)]
-#[phase(syntax, link)] extern crate log;
+#![feature(globs, phase, unsafe_destructor)]
+#[phase(plugin, link)] extern crate log;
 extern crate debug;
 
 /*


### PR DESCRIPTION
- `#[unsafe_destructor]` now requires `#![feature(unsafe_destructor)]`. We can't easily remove it from `impl<'db> Drop for Cursor<'db>` (it uses an internal reference to satisfy the lifetime requirement), so we have to live with it for now.
- The internal reference in `Cursor` has been renamed to start with `_` and thus an unused field warning is suppressed.
- `#![phase(syntax, ...)]` became `#![phase(plugin, ...)]`.
