### PR TITLE
Language changes: *T -> *const T.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ libsqlite*
 *.o
 *.dSYM
 sqlite
+target

--- a/src/sqlite3/cursor.rs
+++ b/src/sqlite3/cursor.rs
@@ -38,11 +38,11 @@ use types::*;
 
 /// The database cursor.
 pub struct Cursor<'db> {
-    stmt: *stmt,
-    _dbh: &'db *dbh
+    stmt: *mut stmt,
+    _dbh: &'db *mut dbh
 }
 
-pub fn cursor_with_statement<'db>(stmt: *stmt, dbh: &'db *dbh) -> Cursor<'db> {
+pub fn cursor_with_statement<'db>(stmt: *mut stmt, dbh: &'db *mut dbh) -> Cursor<'db> {
     debug!("`Cursor.cursor_with_statement()`: stmt={:?}", stmt);
     Cursor { stmt: stmt, _dbh: dbh }
 }
@@ -258,7 +258,7 @@ impl<'db> Cursor<'db> {
                             , i as c_int  // the SQL parameter index (starting from 1)
                             , _v          // the value to bind
                             , l as c_int  // the number of bytes
-                            , -1 as *c_void// SQLITE_TRANSIENT => SQLite makes a copy
+                            , -1 as *mut c_void// SQLITE_TRANSIENT => SQLite makes a copy
                             )
                     }
                 })
@@ -276,7 +276,7 @@ impl<'db> Cursor<'db> {
                             , i as c_int  // the SQL parameter index (starting from 1)
                             , _v          // the value to bind
                             , l as c_int  // the number of bytes
-                            , 0 as *c_void// SQLITE_STATIC
+                            , 0 as *mut c_void// SQLITE_STATIC
                             )
                     }
                 })
@@ -293,7 +293,7 @@ impl<'db> Cursor<'db> {
                         , i as c_int  // the SQL parameter index (starting from 1)
                         , v.as_ptr()  // the value to bind
                         , l as c_int  // the number of bytes
-                        , -1 as *c_void // SQLITE_TRANSIENT => SQLite makes a copy
+                        , -1 as *mut c_void // SQLITE_TRANSIENT => SQLite makes a copy
                         )
                 }
             }

--- a/src/sqlite3/database.rs
+++ b/src/sqlite3/database.rs
@@ -38,10 +38,10 @@ use types::*;
 
 /// The database connection.
 pub struct Database {
-    dbh: *dbh,
+    dbh: *mut dbh,
 }
 
-pub fn database_with_handle(dbh: *dbh) -> Database {
+pub fn database_with_handle(dbh: *mut dbh) -> Database {
     Database { dbh: dbh }
 }
 
@@ -69,10 +69,10 @@ impl Database {
     /// Prepares/compiles an SQL statement.
     /// See http://www.sqlite.org/c3ref/prepare.html
     pub fn prepare<'db>(&'db self, sql: &str, _tail: &Option<&str>) -> SqliteResult<Cursor<'db>> {
-        let new_stmt = ptr::null();
+        let mut new_stmt = ptr::mut_null();
         let r = sql.with_c_str( |_sql| {
             unsafe {
-                sqlite3_prepare_v2(self.dbh, _sql, sql.len() as c_int, &new_stmt, ptr::null())
+                sqlite3_prepare_v2(self.dbh, _sql, sql.len() as c_int, &mut new_stmt, ptr::mut_null())
             }
         });
         if r == SQLITE_OK {
@@ -89,7 +89,7 @@ impl Database {
         let mut r = SQLITE_ERROR;
         sql.with_c_str( |_sql| {
             unsafe {
-                r = sqlite3_exec(self.dbh, _sql, ptr::null(), ptr::null(), ptr::null())
+                r = sqlite3_exec(self.dbh, _sql, ptr::mut_null(), ptr::mut_null(), ptr::mut_null())
             }
         });
 

--- a/src/sqlite3/ffi.rs
+++ b/src/sqlite3/ffi.rs
@@ -34,46 +34,52 @@ use types::*;
 
 #[link(name = "sqlite3")]
 extern {
-    pub fn sqlite3_open(path: *c_char, hnd: **dbh) -> ResultCode;
-    pub fn sqlite3_close(dbh: *dbh) -> ResultCode;
-    pub fn sqlite3_errmsg(dbh: *dbh) -> *c_char;
-    pub fn sqlite3_changes(dbh: *dbh) -> c_int;
-    pub fn sqlite3_last_insert_rowid(dbh: *dbh) -> i64;
-    pub fn sqlite3_complete(sql: *c_char) -> c_int;
+    pub fn sqlite3_open(path: *const c_char, hnd: *mut *mut dbh) -> ResultCode;
+    pub fn sqlite3_close(dbh: *mut dbh) -> ResultCode;
+    pub fn sqlite3_errmsg(dbh: *mut dbh) -> *const c_char;
+    pub fn sqlite3_changes(dbh: *mut dbh) -> c_int;
+    pub fn sqlite3_last_insert_rowid(dbh: *mut dbh) -> i64;
+    pub fn sqlite3_complete(sql: *const c_char) -> c_int;
 
     pub fn sqlite3_prepare_v2(
-        hnd: *dbh,
-        sql: *c_char,
+        hnd: *mut dbh,
+        sql: *const c_char,
         sql_len: c_int,
-        shnd: **stmt,
-        tail: **c_char
+        shnd: *mut *mut stmt,
+        tail: *mut *const c_char
     ) -> ResultCode;
 
-    pub fn sqlite3_exec(dbh: *dbh, sql: *c_char, cb: *_notused, d: *_notused, err: **c_char) -> ResultCode;
+    pub fn sqlite3_exec(
+        dbh: *mut dbh,
+        sql: *const c_char,
+        cb: *mut _notused,
+        d: *mut _notused,
+        err: *mut *mut c_char
+    ) -> ResultCode;
 
-    pub fn sqlite3_step(sth: *stmt) -> ResultCode;
-    pub fn sqlite3_reset(sth: *stmt) -> ResultCode;
-    pub fn sqlite3_finalize(sth: *stmt) -> ResultCode;
-    pub fn sqlite3_clear_bindings(sth: *stmt) -> ResultCode;
+    pub fn sqlite3_step(sth: *mut stmt) -> ResultCode;
+    pub fn sqlite3_reset(sth: *mut stmt) -> ResultCode;
+    pub fn sqlite3_finalize(sth: *mut stmt) -> ResultCode;
+    pub fn sqlite3_clear_bindings(sth: *mut stmt) -> ResultCode;
 
-    pub fn sqlite3_column_name(sth: *stmt, icol: c_int) -> *c_char;
-    pub fn sqlite3_column_type(sth: *stmt, icol: c_int) -> c_int;
-    pub fn sqlite3_data_count(sth: *stmt) -> c_int;
-    pub fn sqlite3_column_bytes(sth: *stmt, icol: c_int) -> c_int;
-    pub fn sqlite3_column_blob(sth: *stmt, icol: c_int) -> *u8;
+    pub fn sqlite3_column_name(sth: *mut stmt, icol: c_int) -> *const c_char;
+    pub fn sqlite3_column_type(sth: *mut stmt, icol: c_int) -> c_int;
+    pub fn sqlite3_data_count(sth: *mut stmt) -> c_int;
+    pub fn sqlite3_column_bytes(sth: *mut stmt, icol: c_int) -> c_int;
+    pub fn sqlite3_column_blob(sth: *mut stmt, icol: c_int) -> *const u8;
 
-    pub fn sqlite3_column_text(sth: *stmt, icol: c_int) -> *c_char;
-    pub fn sqlite3_column_double(sth: *stmt, icol: c_int) -> f64;
-    pub fn sqlite3_column_int(sth: *stmt, icol: c_int) -> c_int;
-    pub fn sqlite3_column_int64(sth: *stmt, icol: c_int) -> i64;
+    pub fn sqlite3_column_text(sth: *mut stmt, icol: c_int) -> *const c_char;
+    pub fn sqlite3_column_double(sth: *mut stmt, icol: c_int) -> f64;
+    pub fn sqlite3_column_int(sth: *mut stmt, icol: c_int) -> c_int;
+    pub fn sqlite3_column_int64(sth: *mut stmt, icol: c_int) -> i64;
 
-    pub fn sqlite3_bind_blob(sth: *stmt, icol: c_int, buf: *u8, buflen: c_int, d: *c_void) -> ResultCode;
-    pub fn sqlite3_bind_text(sth: *stmt, icol: c_int, buf: *c_char, buflen: c_int, d: *c_void) -> ResultCode;
-    pub fn sqlite3_bind_null(sth: *stmt, icol: c_int) -> ResultCode;
-    pub fn sqlite3_bind_int(sth: *stmt, icol: c_int, v: c_int) -> ResultCode;
-    pub fn sqlite3_bind_int64(sth: *stmt, icol: c_int, v: i64) -> ResultCode;
-    pub fn sqlite3_bind_double(sth: *stmt, icol: c_int, value: f64) -> ResultCode;
-    pub fn sqlite3_bind_parameter_index(sth: *stmt, name: *c_char) -> c_int;
+    pub fn sqlite3_bind_blob(sth: *mut stmt, icol: c_int, buf: *const u8, buflen: c_int, d: *mut c_void) -> ResultCode;
+    pub fn sqlite3_bind_text(sth: *mut stmt, icol: c_int, buf: *const c_char, buflen: c_int, d: *mut c_void) -> ResultCode;
+    pub fn sqlite3_bind_null(sth: *mut stmt, icol: c_int) -> ResultCode;
+    pub fn sqlite3_bind_int(sth: *mut stmt, icol: c_int, v: c_int) -> ResultCode;
+    pub fn sqlite3_bind_int64(sth: *mut stmt, icol: c_int, v: i64) -> ResultCode;
+    pub fn sqlite3_bind_double(sth: *mut stmt, icol: c_int, value: f64) -> ResultCode;
+    pub fn sqlite3_bind_parameter_index(sth: *mut stmt, name: *const c_char) -> c_int;
 
-    pub fn sqlite3_busy_timeout(dbh: *dbh, ms: c_int) -> ResultCode;
+    pub fn sqlite3_busy_timeout(dbh: *mut dbh, ms: c_int) -> ResultCode;
 }

--- a/src/sqlite3/lib.rs
+++ b/src/sqlite3/lib.rs
@@ -76,10 +76,10 @@ pub fn sqlite_complete(sql: &str) -> SqliteResult<bool> {
 /// `path` can either be a filesystem path or ":memory:".
 /// See http://www.sqlite.org/c3ref/open.html
 pub fn open(path: &str) -> SqliteResult<Database> {
-    let dbh = ptr::null();
+    let mut dbh = ptr::mut_null();
     let r = path.with_c_str( |_path| {
         unsafe {
-            sqlite3_open(_path, &dbh)
+            sqlite3_open(_path, &mut dbh)
         }
     });
     if r != SQLITE_OK {


### PR DESCRIPTION
This commit also fixes various places where an immutable value is abused as a mutable argument to the SQLite function, which can be very unsafe and prone to otherwise safe optimizations. (An [example](https://github.com/linuxfood/rustsqlite/blob/05d93c1/src/sqlite3/database.rs#L72-L83): `new_stmt` is immutable but it gets changed!) The `sqlite3::ffi` module has been also audited and revised to use mutable raw pointers whenever appropriate.
