### PR TITLE
Fix bind_params off-by-one error

### DIFF
--- a/src/sqlite3/cursor.rs
+++ b/src/sqlite3/cursor.rs
@@ -227,7 +227,8 @@ impl<'db> Cursor<'db> {
 
     ///
     pub fn bind_params(&self, values: &[BindArg]) -> ResultCode {
-        let mut i = 0i;
+        // SQL parameter index (starting from 1).
+        let mut i = 1i;
         for v in values.iter() {
             let r = self.bind_param(i, v);
             if r != SQLITE_OK {

--- a/src/sqlite3/lib.rs
+++ b/src/sqlite3/lib.rs
@@ -224,6 +224,16 @@ mod tests {
     }
 
     #[test]
+    fn prepared_stmt_bind_params() {
+        let database = checked_open();
+
+        checked_exec(&database, "BEGIN; CREATE TABLE IF NOT EXISTS test (name text, id integer); COMMIT;");
+
+        let sth = checked_prepare(&database, "INSERT INTO TEST (name, id) values (?, ?)");
+        assert!(sth.bind_params(&[Integer(12345), Text("test".to_string())]) == SQLITE_OK);
+    }
+
+    #[test]
     fn prepared_stmt_bind_static_text() {
         let database = checked_open();
 


### PR DESCRIPTION
Sqlite3's parameter bindings are numbered from '1', not '0'.  This
allows `Cursor::bind_params` to be used.
