### PR TITLE
Language changes: #![crate_id] -> #![crate_name].

### DIFF
--- a/src/sqlite3/lib.rs
+++ b/src/sqlite3/lib.rs
@@ -1,4 +1,4 @@
-#![crate_id="sqlite3#0.1"]
+#![crate_name = "sqlite3"]
 #![crate_type = "lib"]
 #![feature(globs, phase, unsafe_destructor)]
 #[phase(plugin, link)] extern crate log;


### PR DESCRIPTION
This removes a warning, and also some delicate problems related to LTO linkage due to the name mismatch.
