### PR TITLE
Fix various mutability problems.

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -34,17 +34,20 @@ use ffi::*;
 use libc::c_int;
 use std::ptr;
 use std::string;
+use std::kinds::marker;
 use types::*;
 
 /// The database connection.
 pub struct Database {
     dbh: *mut dbh,
+    _marker: marker::NoSend // make this non-`Send`able
 }
 
 pub fn database_with_handle(dbh: *mut dbh) -> Database {
-    Database { dbh: dbh }
+    Database { dbh: dbh, _marker: marker::NoSend }
 }
 
+#[unsafe_destructor]
 impl Drop for Database {
     /// Closes the database connection.
     /// See http://www.sqlite.org/c3ref/close.html
@@ -115,7 +118,7 @@ impl Database {
 
     /// Sets a busy timeout.
     /// See http://www.sqlite.org/c3ref/busy_timeout.html
-    pub fn set_busy_timeout(&self, ms: int) -> ResultCode {
+    pub fn set_busy_timeout(&mut self, ms: int) -> ResultCode {
         unsafe {
             sqlite3_busy_timeout(self.dbh, ms as c_int)
         }


### PR DESCRIPTION
The fix was planned after #94 but I was a bit late in the party. So, this commit fixes the following:
- Fixed a mistake that `Database` was accidentally `Send`able.
- Made `Cursor::{reset, clear_bindings, step, step_row, get_blob, get_int, get_i64, get_f64, get_text, bind_param, bind_params}` receive `&mut self`.
- Made `Database::set_busy_timeout` receive `&mut self`. `Database::{prepare, exec}` has been left as is, since it is perfectly safe to have multiple cursors (see `prepared_stmt_bind_static_text_interleaved` test for an example). The associated thread safety issue is handled by making `Database` non-`Send`able.

Closes #98, #99, #100, #101 and #103.
