### PR TITLE
Update for removal of reflection in rustc.

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -50,7 +50,7 @@ pub struct Cursor<'db> {
 }
 
 pub fn cursor_with_statement<'db>(stmt: *mut stmt, dbh: &'db *mut dbh) -> Cursor<'db> {
-    debug!("`Cursor.cursor_with_statement()`: stmt={:?}", stmt);
+    debug!("`Cursor.cursor_with_statement()`: stmt={}", stmt);
     Cursor { stmt: stmt, _dbh: dbh }
 }
 
@@ -59,7 +59,7 @@ impl<'db> Drop for Cursor<'db> {
     /// Deletes a prepared SQL statement.
     /// See http://www.sqlite.org/c3ref/finalize.html
     fn drop(&mut self) {
-        debug!("`Cursor.drop()`: stmt={:?}", self.stmt);
+        debug!("`Cursor.drop()`: stmt={}", self.stmt);
         unsafe {
             sqlite3_finalize(self.stmt);
         }
@@ -255,15 +255,15 @@ impl<'db> Cursor<'db> {
     /// See http://www.sqlite.org/c3ref/bind_blob.html
     pub fn bind_param(&mut self, i: int, value: &BindArg) -> ResultCode {
 
-        debug!("`Cursor.bind_param()`: stmt={:?}", self.stmt);
+        debug!("`Cursor.bind_param()`: stmt={}", self.stmt);
 
         let r = match *value {
             Text(ref v) => {
                 let l = v.len();
-                debug!("  `Text`: v={:?}, l={:?}", v, l);
+                debug!("  `Text`: v={}, l={}", v, l);
 
                 (*v).with_c_str( |_v| {
-                    debug!("  _v={:?}", _v);
+                    debug!("  _v={}", _v);
                     unsafe {
                         // FIXME: do not copy the data
                         sqlite3_bind_text(
@@ -279,11 +279,11 @@ impl<'db> Cursor<'db> {
 
             StaticText(ref v) => {
                 let l = v.len();
-                debug!("  `StaticText`: v={:?}, l={:?}", v, l);
+                debug!("  `StaticText`: v={}, l={}", v, l);
 
                 {
                     let _v = v.as_bytes();
-                    debug!("  _v={:?}", _v);
+                    debug!("  _v={}", _v);
                     unsafe {
                         sqlite3_bind_text(
                               self.stmt   // the SQL statement
@@ -298,7 +298,7 @@ impl<'db> Cursor<'db> {
 
             Blob(ref v) => {
                 let l = v.len();
-                debug!("`Blob`: v={:?}, l={:?}", v, l);
+                debug!("`Blob`: v={}, l={}", v, l);
 
                 unsafe {
                     // FIXME: do not copy the data

--- a/src/database.rs
+++ b/src/database.rs
@@ -58,7 +58,7 @@ impl Drop for Database {
     /// Closes the database connection.
     /// See http://www.sqlite.org/c3ref/close.html
     fn drop(&mut self) {
-        debug!("`Database.drop()`: dbh={:?}", self.dbh);
+        debug!("`Database.drop()`: dbh={}", self.dbh);
         unsafe {
             sqlite3_close(self.dbh);
         }
@@ -85,7 +85,7 @@ impl Database {
             }
         });
         if r == SQLITE_OK {
-            debug!("`Database.prepare()`: stmt={:?}", new_stmt);
+            debug!("`Database.prepare()`: stmt={}", new_stmt);
             Ok( cursor_with_statement(new_stmt, &self.dbh))
         } else {
             Err(r)

--- a/src/sqlite3.rs
+++ b/src/sqlite3.rs
@@ -2,7 +2,6 @@
 #![crate_type = "lib"]
 #![feature(globs, phase, unsafe_destructor)]
 #[phase(plugin, link)] extern crate log;
-extern crate debug;
 
 /*
 ** Copyright (c) 2011, Brian Smith <brian@linuxfood.net>
@@ -88,7 +87,7 @@ pub fn open(path: &str) -> SqliteResult<Database> {
         }
         Err(r)
     } else {
-        debug!("`open()`: dbh={:?}", dbh);
+        debug!("`open()`: dbh={}", dbh);
         Ok(database_with_handle(dbh))
     }
 }
@@ -103,7 +102,7 @@ mod tests {
     fn checked_prepare<'db>(database: &'db Database, sql: &str) -> Cursor<'db> {
         match database.prepare(sql, &None) {
             Ok(s)  => s,
-            Err(x) => fail!(format!("sqlite error: \"{}\" ({:?})", database.get_errmsg(), x)),
+            Err(x) => fail!(format!("sqlite error: \"{}\" ({})", database.get_errmsg(), x)),
         }
     }
 
@@ -117,7 +116,7 @@ mod tests {
     fn checked_exec(database: &mut Database, sql: &str) {
         match database.exec(sql) {
             Ok(..) => {}
-            Err(x) => fail!(format!("sqlite error: \"{}\" ({:?})", database.get_errmsg(), x)),
+            Err(x) => fail!(format!("sqlite error: \"{}\" ({})", database.get_errmsg(), x)),
         }
     }
 
@@ -139,7 +138,7 @@ mod tests {
         checked_exec(&mut database, "BEGIN; CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY AUTOINCREMENT); COMMIT;");
         let mut sth = checked_prepare(&database, "INSERT OR IGNORE INTO test (id) VALUES (1)");
         let res = sth.step();
-        debug!("test `prepare_insert_stmt`: res={:?}", res);
+        debug!("test `prepare_insert_stmt`: res={}", res);
     }
 
     #[test]


### PR DESCRIPTION
Replace {:?} with {} and remove reference to debug crate.

Fixes #107
