### PR TITLE
Added imports for enum members

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -37,6 +37,9 @@ use std::str;
 use std::slice;
 use std::c_str::CString;
 use types::*;
+use types::BindArg::*;
+use types::ColumnType::*;
+use types::ResultCode::*;
 
 /// The database cursor.
 ///

--- a/src/database.rs
+++ b/src/database.rs
@@ -36,6 +36,7 @@ use std::ptr;
 use std::string;
 use std::kinds::marker;
 use types::*;
+use types::ResultCode::*;
 
 /// The database connection.
 ///

--- a/src/sqlite3.rs
+++ b/src/sqlite3.rs
@@ -40,6 +40,7 @@ pub use cursor::*;
 pub use database::*;
 use ffi::*;
 pub use types::*;
+use types::ResultCode::*;
 use std::ptr;
 
 pub mod cursor;
@@ -98,6 +99,8 @@ mod tests {
     use database::*;
     use super::*;
     use types::*;
+    use types::BindArg::*;
+    use types::ResultCode::*;
 
     fn checked_prepare<'db>(database: &'db Database, sql: &str) -> Cursor<'db> {
         match database.prepare(sql, &None) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,6 +32,8 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use self::ResultCode::*;
+
 #[deriving(PartialEq, Eq)]
 #[repr(C)]
 pub enum ResultCode {


### PR DESCRIPTION
[This push](https://github.com/rust-lang/rust/pull/18973) breaks `master`.  This pull request fixes the problem.
