### PR TITLE
Derive Clone for enum BindArg

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -104,7 +104,7 @@ impl fmt::Debug for ResultCode {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub enum BindArg {
     Text(String),
     StaticText(&'static str),


### PR DESCRIPTION
I recently faced a problem when cloning a `RowMap`, viz., `BindArg` wasn't cloneable. This patch just adds a `Clone` derivation to `enum BindArg`. 