### PR TITLE
should_fail -> should_panic

### DIFF
--- a/src/sqlite3.rs
+++ b/src/sqlite3.rs
@@ -301,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn failed_prepare() {
         let mut database = checked_open();
 


### PR DESCRIPTION
rustsqlite fails to compile with the latest nightly rustc because it uses the `should_fail` attribute, which has been renamed to `should_panic`.