### PR TITLE
Copy is opt-in, Sync is automatically not implemented for raw pointers, and libc lives on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ authors = [ "" ]
 name = "sqlite3"
 
 [dependencies]
+libc = "0.1.5"
 log = "0.3.1"

--- a/src/database.rs
+++ b/src/database.rs
@@ -35,7 +35,6 @@ use libc::c_int;
 use std::str;
 use std::ptr;
 use std::fmt;
-use std::marker;
 use std::borrow::ToOwned;
 use std::ffi::{CString, CStr};
 use types::*;
@@ -49,14 +48,12 @@ use types::ResultCode::*;
 /// but cannot be shared through `std::sync::RWLock`.
 pub struct Database {
     dbh: *mut dbh,
-    _nocopy: marker::NoCopy,
 }
 
 unsafe impl Send for Database {}
-impl !marker::Sync for Database {}
 
 pub fn database_with_handle(dbh: *mut dbh) -> Database {
-    Database { dbh: dbh, _nocopy: marker::NoCopy }
+    Database { dbh: dbh }
 }
 
 impl fmt::Debug for Database {

--- a/src/sqlite3.rs
+++ b/src/sqlite3.rs
@@ -2,8 +2,6 @@
 #![crate_type = "lib"]
 
 #![allow(missing_copy_implementations)]
-#![feature(optin_builtin_traits)]
-#![feature(core, libc)]
 
 #[macro_use] extern crate log;
 


### PR DESCRIPTION
See [marker.rs](https://github.com/rust-lang/rust/blob/62b30605071698ca38baf103c4666c52b0b30fac/src/libcore/marker.rs) for some discussion of the current state of marker traits. The upshot is that `Copy` is opt-in, so we don't need to explicitly opt out with a `_nocopy` field, and `Database` automatically does not implement `Sync` because it has a `*mut dbh` field.

After this change, this project is compatible with the beta release of rustc. :)
